### PR TITLE
Feat: extend config loader to support .env variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 config = "0.15.11"
+dotenv = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.133"
 axum = "0.8.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,48 @@
 use config::{Config, Environment, File};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use dotenv::dotenv;
 
 /// Loads configuration from a given config file or environment variables.
 pub fn load_config(config_file_path: Option<&Path>) -> anyhow::Result<AppConfig> {
+    // Load .env file if it exists, ignore if not present
+    dotenv().ok();
+
     let mut settings = Config::builder();
 
     if let Some(path) = config_file_path {
         settings = settings.add_source(File::from(path).required(true));
     }
 
-    let settings = settings
-        .add_source(Environment::with_prefix("ZEROOXBRIDGE").separator("__"))
-        .build()?;
+    // Add environment variables with prefix ZEROOXBRIDGE
+    settings = settings.add_source(Environment::with_prefix("ZEROOXBRIDGE").separator("__"));
 
-    Ok(settings.try_deserialize::<AppConfig>()?)
+    // Manually load Herodotus-specific environment variables
+    let herodotus_api_key = std::env::var("HERODOTUS_API_KEY")
+        .map_err(|_| anyhow::anyhow!("HERODOTUS_API_KEY is not set in environment or .env file"))?;
+    
+    if herodotus_api_key.is_empty() {
+        return Err(anyhow::anyhow!("HERODOTUS_API_KEY cannot be empty"));
+    }
+
+    let herodotus_endpoint = std::env::var("HERODOTUS_ENDPOINT")
+        .unwrap_or_else(|_| "https://staging.atlantic.api.herodotus.cloud/atlantic-query".to_string());
+
+    // Log loaded Herodotus config for debugging (use proper logger in production)
+    eprintln!(
+        "Loaded Herodotus config: api_key=****, herodotus_endpoint={}",
+        herodotus_endpoint
+    );
+
+    let mut app_config = settings.build()?.try_deserialize::<AppConfig>()?;
+
+    // Override or set Herodotus config
+    app_config.herodotus = HerodotusConfig {
+        api_key: herodotus_api_key,
+        herodotus_endpoint,
+    };
+
+    Ok(app_config)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -31,6 +59,13 @@ pub struct AppConfig {
     pub merkle: MerkleConfig,
     pub logging: LoggingConfig,
     pub oracle: OracleConfig,
+    pub herodotus: HerodotusConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HerodotusConfig {
+    pub api_key: String,
+    pub herodotus_endpoint: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -105,4 +140,60 @@ pub struct LoggingConfig {
 pub struct OracleConfig {
     pub tolerance_percent: Option<f64>, // e.g., 0.01 for 1%
     pub polling_interval_seconds: u64,  // e.g., 60 seconds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_load_config_with_herodotus_env_vars() {
+        // Set environment variables for testing
+        env::set_var("HERODOTUS_API_KEY", "test_key");
+        env::set_var("HERODOTUS_ENDPOINT", "https://test.api");
+        env::set_var("ZEROOXBRIDGE__SERVER__HOST", "localhost");
+        env::set_var("ZEROOXBRIDGE__SERVER__SERVER_URL", "http://localhost:8080");
+
+        let config = load_config(None).expect("Failed to load config");
+        assert_eq!(config.herodotus.api_key, "test_key");
+        assert_eq!(config.herodotus.herodotus_endpoint, "https://test.api");
+        assert_eq!(config.server.host, "localhost");
+        assert_eq!(config.server.server_url, "http://localhost:8080");
+    }
+
+    #[test]
+    fn test_load_config_missing_herodotus_api_key() {
+        env::remove_var("HERODOTUS_API_KEY");
+        env::set_var("HERODOTUS_ENDPOINT", "https://test.api");
+
+        let result = load_config(None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("HERODOTUS_API_KEY is not set"));
+    }
+
+    #[test]
+    fn test_load_config_empty_herodotus_api_key() {
+        env::set_var("HERODOTUS_API_KEY", "");
+        env::set_var("HERODOTUS_ENDPOINT", "https://test.api");
+
+        let result = load_config(None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("HERODOTUS_API_KEY cannot be empty"));
+    }
+
+    #[test]
+    fn test_load_config_default_herodotus_endpoint() {
+        env::set_var("HERODOTUS_API_KEY", "test_key");
+        env::remove_var("HERODOTUS_ENDPOINT");
+        env::set_var("ZEROOXBRIDGE__SERVER__HOST", "localhost");
+        env::set_var("ZEROOXBRIDGE__SERVER__SERVER_URL", "http://localhost:8080");
+
+        let config = load_config(None).expect("Failed to load config");
+        assert_eq!(config.herodotus.api_key, "test_key");
+        assert_eq!(
+            config.herodotus.herodotus_endpoint,
+            "https://staging.atlantic.api.herodotus.cloud/atlantic-query"
+        );
+    }
 }


### PR DESCRIPTION
close  #21 Extend Config Loader to Support Reading Env Variables

This PR implements support for loading HERODOTUS_API_KEY and HERODOTUS_ENDPOINT from a .env file in the ZeroXBridge Sequencer configuration system, addressing the issue of hardcoded credentials. Key changes:

Added dotenv = "0.15" dependency.
Extended AppConfig with HerodotusConfig struct.
Updated load_config() to load and validate Herodotus API keys from .env or environment variables, with a default endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading and validating Herodotus API configuration from environment variables, including API key and endpoint.
  - Configuration now includes a dedicated section for Herodotus settings, with improved error handling for missing or empty API keys.
- **Bug Fixes**
  - Ensured environment variables from `.env` are always loaded, improving reliability of configuration loading.
- **Tests**
  - Introduced unit tests to verify correct loading and validation of Herodotus environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->