### PR TITLE
sequencer#6: L1 relayer wip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,12 @@ tracing = "0.1.41"
 thiserror = "2.0.12"
 mockall = "0.13.1"
 sha2 = "0.10"
+alloy-json-rpc = "0.15.6"
+alloy-primitives = "1.0.0"
+alloy-rpc-client = "0.15.6"
+alloy-transport-http = "0.15.6"
+url = "2.5.4"
+alloy-sol-types = "1.0.0"
 
 [package.metadata.sqlx]
 offline = true

--- a/migrations/20250428032930_create_deposits_table.sql
+++ b/migrations/20250428032930_create_deposits_table.sql
@@ -1,0 +1,23 @@
+-- Create deposits table
+CREATE TABLE IF NOT EXISTS deposits (
+    id SERIAL PRIMARY KEY,
+    user_address TEXT NOT NULL,
+    amount BIGINT NOT NULL,
+    l2_tx_id INTEGER,
+    commitment_hash TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create deposit_proofs table
+CREATE TABLE IF NOT EXISTS deposit_proofs (
+    id SERIAL PRIMARY KEY,
+    deposit_id INTEGER REFERENCES deposits(id),
+    proof_params BYTEA,
+    proof_data BYTEA,
+    status TEXT NOT NULL DEFAULT 'ready',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,6 @@ pub mod queue {
     pub mod l1_queue;
     pub mod l2_queue;
 }
+pub mod relayer {
+    pub mod ethereum_relayer;
+}

--- a/src/relayer/ethereum_relayer.rs
+++ b/src/relayer/ethereum_relayer.rs
@@ -1,0 +1,436 @@
+use crate::config::RelayerConfig;
+use alloy_json_rpc::RpcError;
+use alloy_primitives::{hex, Address, U256};
+use alloy_rpc_client::{ClientBuilder, RpcClient};
+use alloy_sol_types::{sol, SolCall};
+use sqlx::{PgConnection, PgPool};
+use std::time::Duration;
+use thiserror::Error;
+use tokio::time::sleep;
+use tracing::{error, info, trace, warn};
+use url::Url;
+
+sol! {
+    function unlock_funds_with_proof(
+        uint256[] calldata proofParams,
+        uint256[] calldata proof,
+        address user,
+        uint256 amount,
+        uint256 l2TxId,
+        bytes32 commitmentHash
+    ) external;
+}
+
+#[derive(Debug, Error)]
+pub enum RelayerError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    #[error("Ethereum RPC error: {0}")]
+    RpcError(String),
+
+    #[error("Contract error: {0}")]
+    ContractError(String),
+
+    #[error("Transaction failed: {0}")]
+    TransactionFailed(String),
+
+    #[error("Failed to fetch proof: {0}")]
+    ProofFetchFailed(String),
+}
+
+/// Data structure for deposit with proof
+#[derive(Debug)]
+pub struct DepositWithProof {
+    pub deposit_id: i32,
+    pub user_address: String,
+    pub amount: i64,
+    pub l2_tx_id: String,
+    pub commitment_hash: String,
+    pub proof_params: Vec<u8>,
+    pub proof_data: Vec<u8>,
+}
+
+/// Relayer for sending L1 transactions to Ethereum
+pub struct EthereumRelayer {
+    db_pool: PgPool,
+    client: RpcClient,
+    contract_address: Address,
+    config: RelayerConfig,
+}
+
+impl EthereumRelayer {
+    /// Create a new Ethereum relayer
+    pub async fn new(
+        db_pool: PgPool,
+        ethereum_rpc_url: Url,
+        contract_address: &str,
+        config: RelayerConfig,
+    ) -> Result<Self, RelayerError> {
+        let client = ClientBuilder::default().http(ethereum_rpc_url);
+
+        let contract_address = contract_address
+            .parse::<Address>()
+            .map_err(|e| RelayerError::ContractError(format!("Invalid contract address: {}", e)))?;
+
+        Ok(Self {
+            db_pool,
+            client,
+            contract_address,
+            config,
+        })
+    }
+
+    /// Run the relayer in an infinite loop
+    pub async fn run(&self) {
+        loop {
+            match self.process_relay_transactions().await {
+                Ok(_) => info!("Completed relay processing cycle"),
+                Err(e) => error!("Relay processing cycle failed: {:?}", e),
+            }
+            sleep(Duration::from_secs(self.config.retry_delay_seconds.into())).await;
+        }
+    }
+
+    /// Process transactions that are ready to be relayed
+    async fn process_relay_transactions(&self) -> Result<(), RelayerError> {
+        let deposits_to_relay = self.fetch_ready_for_relay_deposits().await?;
+
+        for deposit in deposits_to_relay {
+            let mut tx = self.db_pool.begin().await?;
+
+            match self.relay_transaction(&deposit).await {
+                Ok(_) => {
+                    info!(
+                        "Successfully relayed transaction for deposit {}",
+                        deposit.deposit_id
+                    );
+                    self.update_deposit_status(&mut tx, deposit.deposit_id, "relayed")
+                        .await?;
+                }
+                Err(e) => {
+                    let retry_count = self.get_retry_count(&deposit.deposit_id).await?;
+                    if retry_count >= self.config.max_retries as i32 - 1 {
+                        error!(
+                            "Max retries reached for deposit {}. Marking as failed: {:?}",
+                            deposit.deposit_id, e
+                        );
+                        self.update_deposit_status(&mut tx, deposit.deposit_id, "failed")
+                            .await?;
+                    } else {
+                        warn!(
+                            "Failed to relay transaction for deposit {}. Will retry: {:?}",
+                            deposit.deposit_id, e
+                        );
+                        self.increment_retry_count(&mut tx, deposit.deposit_id)
+                            .await?;
+                    }
+                }
+            }
+
+            tx.commit().await?;
+
+            // small delay between sending transactions to avoid nonce issues
+            sleep(Duration::from_millis(500)).await;
+        }
+
+        Ok(())
+    }
+
+    /// Get the retry count for a deposit
+    async fn get_retry_count(&self, deposit_id: &i32) -> Result<i32, RelayerError> {
+        let retry_count = sqlx::query!(
+            r#"
+            SELECT retry_count FROM deposits
+            WHERE id = $1
+            "#,
+            deposit_id
+        )
+        .fetch_one(&self.db_pool)
+        .await?
+        .retry_count;
+
+        Ok(retry_count)
+    }
+
+    /// Fetch deposits that are ready to be relayed with their proofs
+    async fn fetch_ready_for_relay_deposits(&self) -> Result<Vec<DepositWithProof>, RelayerError> {
+        let records = sqlx::query!(
+            r#"
+            SELECT d.id, d.user_address, d.amount, d.l2_tx_id, d.commitment_hash, 
+                  dp.proof_params, dp.proof_data 
+            FROM deposits d
+            JOIN deposit_proofs dp ON d.id = dp.deposit_id
+            WHERE d.status = 'ready_for_relay' AND d.retry_count < $1 AND dp.status = 'ready'
+            ORDER BY d.created_at ASC
+            LIMIT 10
+            "#,
+            self.config.max_retries as i32
+        )
+        .fetch_all(&self.db_pool)
+        .await?;
+
+        let deposits_with_proofs = records
+            .into_iter()
+            .map(|row| DepositWithProof {
+                deposit_id: row.id,
+                user_address: row.user_address,
+                amount: row.amount,
+                l2_tx_id: row.l2_tx_id.map_or(String::new(), |id| id.to_string()),
+                commitment_hash: row.commitment_hash,
+                proof_params: row.proof_params.unwrap_or_default(),
+                proof_data: row.proof_data.unwrap_or_default(),
+            })
+            .collect();
+
+        Ok(deposits_with_proofs)
+    }
+
+    /// Update the status of a deposit
+    async fn update_deposit_status(
+        &self,
+        conn: &mut PgConnection,
+        id: i32,
+        status: &str,
+    ) -> Result<(), RelayerError> {
+        sqlx::query!(
+            r#"
+            UPDATE deposits 
+            SET status = $2, updated_at = NOW()
+            WHERE id = $1
+            "#,
+            id,
+            status
+        )
+        .execute(conn)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Increment the retry count for a deposit
+    async fn increment_retry_count(
+        &self,
+        conn: &mut PgConnection,
+        id: i32,
+    ) -> Result<(), RelayerError> {
+        sqlx::query!(
+            r#"
+            UPDATE deposits 
+            SET retry_count = retry_count + 1, updated_at = NOW()
+            WHERE id = $1
+            "#,
+            id
+        )
+        .execute(conn)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Relay a transaction to Ethereum
+    async fn relay_transaction(&self, deposit: &DepositWithProof) -> Result<(), RelayerError> {
+        // Try to send the transaction with retry logic
+        let mut retry_count = 0;
+        while retry_count < self.config.max_retries {
+            trace!(
+                "Attempting to relay transaction for deposit {}, attempt {}/{}",
+                deposit.deposit_id,
+                retry_count + 1,
+                self.config.max_retries
+            );
+
+            match self.send_unlock_funds_transaction(deposit).await {
+                Ok(_) => {
+                    info!(
+                        "Transaction for deposit {} successfully sent",
+                        deposit.deposit_id
+                    );
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!("Failed to send transaction for deposit {}: {:?}. Retrying in {} seconds...", 
+                          deposit.deposit_id, e, self.config.retry_delay_seconds);
+
+                    retry_count += 1;
+                    if retry_count < self.config.max_retries {
+                        sleep(Duration::from_secs(self.config.retry_delay_seconds.into())).await;
+                    }
+                }
+            }
+        }
+
+        Err(RelayerError::TransactionFailed(format!(
+            "Failed to send transaction after {} retries",
+            self.config.max_retries
+        )))
+    }
+
+    /// Send an Ethereum transaction to the unlock_funds_with_proof function
+    async fn send_unlock_funds_transaction(
+        &self,
+        deposit: &DepositWithProof,
+    ) -> Result<(), RelayerError> {
+        let accounts: Vec<Address> = self
+            .client
+            .request_noparams("eth_accounts")
+            .await
+            .map_err(|e| RelayerError::RpcError(e.to_string()))?;
+
+        if accounts.is_empty() {
+            return Err(RelayerError::RpcError("No accounts available".to_string()));
+        }
+
+        let from = accounts[0];
+
+        let gas_price: U256 = self
+            .client
+            .request_noparams("eth_gasPrice")
+            .await
+            .map_err(|e| RelayerError::RpcError(e.to_string()))?;
+
+        let nonce: U256 = self
+            .client
+            .request("eth_getTransactionCount", (from, "latest"))
+            .await
+            .map_err(|e| RelayerError::RpcError(e.to_string()))?;
+
+        // Parse user address
+        let user_address = deposit
+            .user_address
+            .parse::<Address>()
+            .map_err(|e| RelayerError::ContractError(format!("Invalid user address: {}", e)))?;
+
+        // Parse amount
+        let amount = U256::from(deposit.amount);
+
+        // Parse L2 TX ID, defaulting to 0 if empty
+        let l2_tx_id = if deposit.l2_tx_id.is_empty() {
+            U256::ZERO
+        } else {
+            U256::from_str_radix(&deposit.l2_tx_id, 10)
+                .map_err(|e| RelayerError::ContractError(format!("Invalid L2 TX ID: {}", e)))?
+        };
+
+        // Parse commitment hash to bytes32
+        let commitment_hash_str = deposit
+            .commitment_hash
+            .strip_prefix("0x")
+            .unwrap_or(&deposit.commitment_hash);
+        let commitment_hash = hex::decode(commitment_hash_str)
+            .map_err(|e| RelayerError::ContractError(format!("Invalid commitment hash: {}", e)))?;
+
+        // Pad or truncate to 32 bytes
+        let mut commitment_bytes32 = [0u8; 32];
+        let len = commitment_hash.len().min(32);
+        commitment_bytes32[..len].copy_from_slice(&commitment_hash[..len]);
+
+        // Convert proof_params and proof_data from bytes to Vec<U256>
+        let proof_params = self.decode_uint_array_from_bytes(&deposit.proof_params)?;
+        let proof = self.decode_uint_array_from_bytes(&deposit.proof_data)?;
+
+        // Create the function call using alloy_sol_types
+        let call = unlock_funds_with_proofCall {
+            proofParams: proof_params,
+            proof,
+            user: user_address,
+            amount,
+            l2TxId: l2_tx_id,
+            commitmentHash: alloy_primitives::FixedBytes(commitment_bytes32),
+        };
+
+        let call_data = call.abi_encode();
+
+        let tx_params = serde_json::json!({
+            "from": from,
+            "to": self.contract_address,
+            "gas": format!("0x{:x}", self.config.gas_limit),
+            "gasPrice": format!("0x{:x}", gas_price),
+            "nonce": format!("0x{:x}", nonce),
+            "data": format!("0x{}", hex::encode(&call_data)),
+        });
+
+        let tx_hash: String = self
+            .client
+            .request("eth_sendTransaction", [tx_params])
+            .await
+            .map_err(|e| match e {
+                RpcError::ErrorResp(payload) => RelayerError::RpcError(format!(
+                    "RPC error {} - {}",
+                    payload.code, payload.message
+                )),
+                RpcError::Transport(e) => RelayerError::RpcError(format!("Transport error: {}", e)),
+                _ => RelayerError::RpcError(e.to_string()),
+            })?;
+
+        self.wait_for_transaction_receipt(&tx_hash).await?;
+
+        Ok(())
+    }
+
+    /// Decode bytes to an array of U256 integers
+    fn decode_uint_array_from_bytes(&self, bytes: &[u8]) -> Result<Vec<U256>, RelayerError> {
+        let mut result = Vec::new();
+        let mut i = 0;
+
+        // Simple decoding
+        while i + 32 <= bytes.len() {
+            let mut word = [0u8; 32];
+            word.copy_from_slice(&bytes[i..i + 32]);
+            result.push(U256::from_be_bytes(word));
+            i += 32;
+        }
+
+        Ok(result)
+    }
+
+    /// Wait for a transaction receipt
+    async fn wait_for_transaction_receipt(&self, tx_hash: &str) -> Result<(), RelayerError> {
+        // Ensure tx_hash starts with 0x
+        let tx_hash = if !tx_hash.starts_with("0x") {
+            format!("0x{}", tx_hash)
+        } else {
+            tx_hash.to_string()
+        };
+
+        for _ in 0..60 {
+            // Try for up to 5 minutes (60 * 5s)
+            // Poll for receipt
+            let receipt: Option<serde_json::Value> = self
+                .client
+                .request("eth_getTransactionReceipt", [&tx_hash])
+                .await
+                .map_err(|e| RelayerError::RpcError(e.to_string()))?;
+
+            if let Some(receipt) = receipt {
+                // Check status (1 = success, 0 = failure)
+                let status = receipt["status"]
+                    .as_str()
+                    .unwrap_or("0x0")
+                    .trim_start_matches("0x");
+
+                let status_value = u64::from_str_radix(status, 16)
+                    .map_err(|_| RelayerError::RpcError("Invalid status format".to_string()))?;
+
+                if status_value == 1 {
+                    return Ok(());
+                } else {
+                    return Err(RelayerError::TransactionFailed(format!(
+                        "Transaction failed: {}",
+                        tx_hash
+                    )));
+                }
+            }
+
+            sleep(Duration::from_secs(5)).await;
+        }
+
+        Err(RelayerError::TransactionFailed(format!(
+            "Transaction confirmation timeout: {}",
+            tx_hash
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {}


### PR DESCRIPTION
### related issue #6 

## PR Description
(WIP to show my progress) This PR implements the Ethereum Relayer component as specified in the issue(not yet integrated fully within the sequencer).
The relayer is responsible for sending deposit proofs to L1 after proof generation

### Features implemented:
- created the `EthereumRelayer` struct that handles L1 transaction relay.
- implemented fetching of ready for relay transactions from the database
- added proper transaction contruction with `alloy`
- configurable JSON-RPC communication with configurable providers

### Implementation details
- The relayer polls the database for transactions marked as "ready_for_relay"
- For each transaction, it constructs an Ethereum transaction with proper proof encoding
- Implements configurable retry logic with backoff
- Failed transactions are properly marked after max retries
- Includes detailed logging for monitoring transaction status

## Problems encountered
I encountered some compilation errors with the existing codebase that prevent me for testing:
<img width="1057" alt="Screenshot 2025-04-28 at 20 02 38" src="https://github.com/user-attachments/assets/53e4aaec-ca47-4cf7-a4bd-61fef8d8a1f7" />

I'd appreciate guidance on how to proceed for the tests