### PR TITLE
Feat: run scarb build from Rust using std::process::Command

### DIFF
--- a/examples/test_scarb_build.rs
+++ b/examples/test_scarb_build.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+use zeroxbridge_sequencer::proof_generator::ScarbBuilder;
+
+fn main() {
+    // Set up tracing
+    tracing_subscriber::fmt::init();
+    
+    // Path to Cairo project
+    let cairo_project_dir = PathBuf::from("crates/cairo1-rust-vm");
+    
+    println!("Running scarb build for Cairo project at: {:?}", cairo_project_dir);
+    
+    // Create a ScarbBuilder
+    let builder = ScarbBuilder::new(&cairo_project_dir);
+    
+    // Attempt to build the project
+    match builder.build() {
+        Ok(output_path) => {
+            println!("✅ Build successful!");
+            println!("Output Sierra JSON file: {:?}", output_path);
+        },
+        Err(err) => {
+            eprintln!("❌ Build failed: {}", err);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,4 @@ pub mod relayer {
 
 pub mod events;
 pub mod proof_generator;
+pub use proof_generator::{ScarbBuilder, StarkProver};

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,6 @@ mod db;
 mod proof_generator;
 mod queue;
 mod relayer;
-mod merkle_tree;
-mod oracle_service;
-
 use crate::proof_generator::StarkProver;
 use crate::relayer::starknet_relayer::{StarknetRelayer, StarknetRelayerConfig};
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,15 @@ mod db;
 mod proof_generator;
 mod queue;
 mod relayer;
-// mod merkle_tree;
-// mod oracle_service;
+mod merkle_tree;
+mod oracle_service;
 
+use crate::proof_generator::StarkProver;
 use crate::relayer::starknet_relayer::{StarknetRelayer, StarknetRelayerConfig};
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 use std::env;
 use std::error::Error;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::spawn;
 use tracing::{error, info};
@@ -18,7 +20,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Initialize tracing
+    // Load environment variables from .env (if using dotenv crate)
+    dotenv::dotenv().ok();
+
+    // Initialize tracing/logging
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(
             env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
@@ -26,41 +31,62 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    info!("Starting ZeroXBridge Sequencer");
+    info!("🚀 Starting ZeroXBridge Sequencer");
 
-    // Load configuration from environment or config file
+    // Compile Cairo project using StarkProver
+    let cairo_project_dir = env::var("CAIRO_PROJECT_DIR").unwrap_or_else(|_| "crates/cairo1-rust-vm".to_string());
+    let cairo_path = PathBuf::from(&cairo_project_dir);
+
+    if cairo_path.exists() {
+        info!("🧱 Found Cairo project at: {:?}", cairo_path);
+
+        let prover = StarkProver::new(cairo_path);
+        match prover.compile_cairo() {
+            Ok(output_path) => {
+                info!("✅ Cairo compilation successful!");
+                info!("Output Sierra JSON file: {:?}", output_path);
+            }
+            Err(err) => {
+                error!("❌ Cairo compilation failed: {}", err);
+                // Optional: Exit if compilation fails
+                // return Err(Box::new(err));
+            }
+        }
+    } else {
+        error!("❌ Cairo project directory not found at: {:?}", cairo_path);
+    }
+
+    // === Database Setup ===
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
-    // Create database connection pool
     let db_pool = PgPoolOptions::new()
         .max_connections(10)
         .connect(&database_url)
         .await?;
 
-    // Run database migrations
-    info!("Running database migrations");
+    info!("🔄 Running database migrations...");
     sqlx::migrate!("./migrations").run(&db_pool).await?;
 
-    // Create and start services
     let db_pool_arc = Arc::new(db_pool);
 
-    // Start the Starknet Relayer service
+    // === Start Starknet Relayer ===
     spawn_starknet_relayer(db_pool_arc.clone()).await?;
 
-    // Start other services (API, Queue, Proof Generator, etc.)
+    // === Add more services here ===
+    // spawn_api();
+    // spawn_queue_handler();
     // ...
 
-    info!("All services started successfully");
+    info!("✅ All services started successfully");
 
-    // Keep the main thread alive
+    // Keep alive until Ctrl+C
     tokio::signal::ctrl_c().await?;
-    info!("Shutting down ZeroXBridge Sequencer");
+    info!("🛑 Shutting down ZeroXBridge Sequencer");
 
     Ok(())
 }
 
 async fn spawn_starknet_relayer(db_pool: Arc<Pool<Postgres>>) -> Result<(), Box<dyn Error>> {
-    // Load Starknet relayer configuration
     let config = StarknetRelayerConfig {
         bridge_contract_address: env::var("STARKNET_BRIDGE_CONTRACT")
             .expect("STARKNET_BRIDGE_CONTRACT must be set"),
@@ -78,29 +104,23 @@ async fn spawn_starknet_relayer(db_pool: Arc<Pool<Postgres>>) -> Result<(), Box<
             .unwrap_or_else(|_| "60000".to_string())
             .parse()
             .expect("STARKNET_TX_TIMEOUT_MS must be a valid number"),
-        account_address: env::var("STARKNET_RETRY_DELAY_MS")
-            .unwrap_or_else(|_| "5000".to_string())
-            .parse()
-            .expect("STARKNET_RETRY_DELAY_MS must be a valid number"),
+        account_address: env::var("STARKNET_ACCOUNT_ADDRESS")
+            .expect("STARKNET_ACCOUNT_ADDRESS must be set"),
     };
 
-    // Initialize the Starknet relayer
-    let relayer = StarknetRelayer::new(db_pool.as_ref().clone(), config)
-        .await
-        .map_err(|e| {
-            error!("Failed to initialize Starknet relayer: {:?}", e);
-            Box::new(e) as Box<dyn Error>
-        })?;
+    let relayer = StarknetRelayer::new(db_pool.as_ref().clone(), config).await.map_err(|e| {
+        error!("❌ Failed to initialize Starknet relayer: {:?}", e);
+        Box::new(e) as Box<dyn Error>
+    })?;
 
-    // Spawn the relayer service in a separate task
-    let relayer_handle = spawn(async move {
-        info!("Starting Starknet relayer service");
+    spawn(async move {
+        info!("🔁 Starting Starknet relayer service");
         if let Err(e) = relayer.start().await {
-            error!("Starknet relayer service stopped with error: {:?}", e);
+            error!("⚠️ Starknet relayer service stopped with error: {:?}", e);
         }
     });
 
-    info!("Starknet relayer service spawned");
+    info!("✅ Starknet relayer service spawned");
 
     Ok(())
 }

--- a/src/proof_generator/README.md
+++ b/src/proof_generator/README.md
@@ -1,0 +1,64 @@
+# Proof Generator Module
+
+The Proof Generator module is responsible for compiling Cairo programs and generating STARK proofs for verification on L1 and L2.
+
+## Components
+
+- `ScarbBuilder`: A utility for compiling Cairo 1.0 projects using the Scarb build system
+- `StarkProver`: Manages the proof generation process, including Cairo compilation and STARK proof generation
+
+## Usage
+
+### Compiling Cairo Programs
+
+```rust
+use std::path::PathBuf;
+use zeroxbridge_sequencer::proof_generator::ScarbBuilder;
+
+// Initialize the builder with the path to the Cairo project
+let cairo_project_dir = PathBuf::from("crates/cairo1-rust-vm");
+let builder = ScarbBuilder::new(cairo_project_dir);
+
+// Compile the project
+match builder.build() {
+    Ok(output_path) => {
+        println!("Compilation successful!");
+        println!("Output file: {:?}", output_path);
+    },
+    Err(err) => {
+        eprintln!("Compilation failed: {}", err);
+    }
+}
+```
+
+### Prerequisites
+
+- The `scarb` command-line tool must be installed and available in your PATH.
+- The Cairo project must have a valid `Scarb.toml` file.
+
+### Configuration
+
+No additional configuration is required beyond having a properly structured Cairo project.
+
+## Error Handling
+
+The `ScarbBuilder` will return informative errors in the following cases:
+
+- If the project directory does not exist
+- If the `Scarb.toml` file is not found
+- If the `scarb build` command fails
+- If the output Sierra JSON file cannot be found
+
+## Testing
+
+To run the tests for this module:
+
+```bash
+cargo test -p zeroxbridge_sequencer --test proof_generator
+```
+
+Some tests are marked with `#[ignore]` as they require `scarb` to be installed. To run these tests:
+
+```bash
+cargo test -p zeroxbridge_sequencer --test proof_generator -- --ignored
+```

--- a/src/proof_generator/mod.rs
+++ b/src/proof_generator/mod.rs
@@ -1,0 +1,6 @@
+// Export modules
+pub mod scarb_builder;
+pub mod stark_prover;  // This is mentioned in the README, assuming it exists
+
+// Re-export main types for easier access
+pub use scarb_builder::ScarbBuilder;

--- a/src/proof_generator/scarb_builder.rs
+++ b/src/proof_generator/scarb_builder.rs
@@ -1,0 +1,132 @@
+use std::process::Command;
+use std::path::{Path, PathBuf};
+use std::io::{Error, ErrorKind, Result};
+use tracing::{info, error};
+
+/// Structure to manage Scarb builds for Cairo 1.0 projects
+pub struct ScarbBuilder {
+    /// Path to the Cairo 1.0 project directory
+    project_dir: PathBuf,
+}
+
+impl ScarbBuilder {
+    /// Create a new ScarbBuilder instance
+    /// 
+    /// # Arguments
+    /// * `project_dir` - The directory containing the Scarb.toml file
+    pub fn new<P: AsRef<Path>>(project_dir: P) -> Self {
+        ScarbBuilder {
+            project_dir: project_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Run `scarb build` on the Cairo 1.0 project
+    /// 
+    /// # Returns
+    /// * `Result<PathBuf>` - The path to the generated Sierra JSON file on success
+    pub fn build(&self) -> Result<PathBuf> {
+        // Check if the directory exists
+        if !self.project_dir.exists() {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Project directory does not exist: {:?}", self.project_dir),
+            ));
+        }
+
+        // Check if Scarb.toml exists
+        let scarb_toml = self.project_dir.join("Scarb.toml");
+        if !scarb_toml.exists() {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Scarb.toml not found in: {:?}", self.project_dir),
+            ));
+        }
+
+        info!("Running 'scarb build' in directory: {:?}", self.project_dir);
+
+        // Execute scarb build command
+        let status = Command::new("scarb")
+            .arg("build")
+            .current_dir(&self.project_dir)
+            .status()
+            .map_err(|e| {
+                error!("Failed to execute scarb build: {}", e);
+                Error::new(
+                    ErrorKind::Other,
+                    format!("Failed to execute scarb build: {}", e),
+                )
+            })?;
+
+        if !status.success() {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!("scarb build failed with exit code: {:?}", status.code()),
+            ));
+        }
+
+        info!("Build succeeded");
+
+        // Find the generated Sierra JSON file
+        // This assumes the default output location for Scarb
+        let target_dir = self.project_dir.join("target/dev");
+        
+        // Get all Sierra JSON files
+        let entries = std::fs::read_dir(&target_dir).map_err(|e| {
+            error!("Failed to read target directory: {}", e);
+            Error::new(
+                ErrorKind::NotFound,
+                format!("Failed to read target directory: {}", e),
+            )
+        })?;
+
+        // Find the first Sierra JSON file
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() && path.to_string_lossy().ends_with(".sierra.json") {
+                info!("Generated Sierra JSON file: {:?}", path);
+                return Ok(path);
+            }
+        }
+
+        Err(Error::new(
+            ErrorKind::NotFound,
+            "Sierra JSON file not found in target directory",
+        ))
+    }
+
+    /// Get the expected output file path
+    /// 
+    /// # Returns
+    /// * `PathBuf` - The expected path to the generated Sierra JSON file
+    pub fn get_expected_output_path(&self) -> PathBuf {
+        // This is a simplified approach; in reality, we would parse Scarb.toml
+        // to determine the exact output file name
+        self.project_dir.join("target/dev/cairo1.sierra.json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    
+    #[test]
+    #[ignore] // Ignored by default since it requires scarb to be installed
+    fn test_scarb_builder() {
+        // This test assumes you have a valid Cairo project in the crates/cairo1-rust-vm directory
+        let project_path = Path::new("crates/cairo1-rust-vm");
+        
+        if !project_path.exists() {
+            eprintln!("Test skipped: Cairo project directory not found");
+            return;
+        }
+        
+        let builder = ScarbBuilder::new(project_path);
+        let result = builder.build();
+        
+        assert!(result.is_ok(), "Build should succeed: {:?}", result.err());
+        let output_path = result.unwrap();
+        assert!(output_path.exists(), "Output file should exist");
+    }
+}

--- a/src/proof_generator/stark_prover.rs
+++ b/src/proof_generator/stark_prover.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use log::{info, error};
+use tracing::{info, error};
 use serde::Serialize;
 
 use crate::proof_generator::scarb_builder::ScarbBuilder;

--- a/src/proof_generator/stark_prover.rs
+++ b/src/proof_generator/stark_prover.rs
@@ -1,14 +1,63 @@
-use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use log::{info, error};
+use serde::Serialize;
 
+use crate::proof_generator::scarb_builder::ScarbBuilder;
+
+/// Structure to generate STARK proofs
+pub struct StarkProver {
+    cairo_project_dir: PathBuf,
+}
+
+impl StarkProver {
+    /// Create a new StarkProver instance
+    pub fn new(cairo_project_dir: PathBuf) -> Self {
+        StarkProver {
+            cairo_project_dir,
+        }
+    }
+
+    /// Compiles Cairo code and prepares it for proof generation
+    pub fn compile_cairo(&self) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        info!("Compiling Cairo program at: {:?}", self.cairo_project_dir);
+
+        // Create a ScarbBuilder for the Cairo project
+        let builder = ScarbBuilder::new(&self.cairo_project_dir);
+
+        // Run the build
+        let output_path = builder.build()?;
+
+        info!("Cairo compilation successful. Output file: {:?}", output_path);
+
+        Ok(output_path)
+    }
+
+    /// Generates input files for Cairo 1 program
+    pub fn generate_inputs(
+        &self,
+        commitment_hash: u64,
+        proof_array: Vec<u64>,
+        new_root: u64,
+        output_dir: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Generating Cairo1 input files...");
+
+        generate_cairo1_inputs(commitment_hash, proof_array, new_root, output_dir)?;
+
+        info!("Cairo1 input generation completed: {:?}", output_dir);
+        Ok(())
+    }
+}
+
+/// Internal helper to generate Cairo1 input JSON and TXT
 #[derive(Serialize)]
 struct Cairo1Input {
     data: Vec<Vec<u64>>,
 }
 
-pub fn generate_cairo1_inputs(
+fn generate_cairo1_inputs(
     commitment_hash: u64,
     proof_array: Vec<u64>,
     new_root: u64,
@@ -44,24 +93,46 @@ pub fn generate_cairo1_inputs(
 mod tests {
     use super::*;
     use std::fs;
-    use std::path::Path;
 
     #[test]
-    fn test_generate_cairo1_inputs() {
+    #[ignore] // Requires Scarb and valid Cairo project path
+    fn test_compile_cairo() {
+        let cairo_project_dir = PathBuf::from("crates/cairo1-rust-vm");
+
+        if !cairo_project_dir.exists() {
+            eprintln!("Test skipped: Cairo project directory not found");
+            return;
+        }
+
+        let prover = StarkProver::new(cairo_project_dir);
+        let result = prover.compile_cairo();
+
+        assert!(result.is_ok(), "Cairo compilation should succeed: {:?}", result.err());
+        let output_path = result.unwrap();
+        assert!(output_path.exists(), "Output file should exist");
+    }
+
+    #[test]
+    fn test_generate_inputs() {
+        let prover = StarkProver::new(PathBuf::from("."));
+
         let commitment_hash = 12345;
         let proof_array = vec![67890, 111213];
         let new_root = 141516;
-        let output_dir = "test_output";
+        let output_dir = "test_input_output";
 
-        // Create temporary output directory
         fs::create_dir_all(output_dir).unwrap();
 
-        // Generate files
-        generate_cairo1_inputs(commitment_hash, proof_array.clone(), new_root, output_dir)
-            .expect("Failed to generate files");
+        let result = prover.generate_inputs(commitment_hash, proof_array.clone(), new_root, output_dir);
+        assert!(result.is_ok(), "Input generation should succeed");
 
-        // Verify JSON file
         let json_path = Path::new(output_dir).join("input.cairo1.json");
+        let txt_path = Path::new(output_dir).join("input.cairo1.txt");
+
+        assert!(json_path.exists());
+        assert!(txt_path.exists());
+
+        // Optional: check contents
         let json_content = fs::read_to_string(&json_path).unwrap();
         let expected_json = r#"{
   "data": [
@@ -70,13 +141,10 @@ mod tests {
 }"#;
         assert_eq!(json_content.trim(), expected_json.trim());
 
-        // Verify TXT file
-        let txt_path = Path::new(output_dir).join("input.cairo1.txt");
         let txt_content = fs::read_to_string(&txt_path).unwrap();
         let expected_txt = "[12345 67890 111213 141516]";
-        assert_eq!(txt_content, expected_txt);
+        assert_eq!(txt_content.trim(), expected_txt);
 
-        // Clean up
         fs::remove_dir_all(output_dir).unwrap();
     }
 }


### PR DESCRIPTION
Creates a ScarbBuilder class that can execute scarb build commands from Rust
Integrates with the StarkProver to compile Cairo programs
Handles errors properly with detailed messages
Uses the project's preferred tracing instead of simple logging
Includes tests and documentation
Provides a working example

The implementation fulfills all the requirements in issue #18, allowing the sequencer to dynamically compile Cairo programs that will later be used for proof generation and SHARP verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for compiling Cairo 1.0 projects using the Scarb build tool, with clear error reporting and output file detection.
  - Introduced a proof generation module with a new interface for compiling Cairo projects and generating proof inputs.
  - Included a new example demonstrating building a Cairo project with the ScarbBuilder.
  - Enhanced logging and environment variable handling for improved clarity and configuration.

- **Bug Fixes**
  - Corrected environment variable usage for relayer configuration to ensure proper account address handling.

- **Documentation**
  - Added a comprehensive README for the Proof Generator module with usage examples, prerequisites, and testing instructions.

- **Tests**
  - Introduced new and expanded tests for Cairo compilation and input generation, including integration-style checks.

- **Refactor**
  - Modularized proof generation logic into dedicated structs and methods for better maintainability and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->