### PR TITLE
feat: execute scarb build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5013,9 +5013,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -5851,9 +5851,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
@@ -6117,9 +6117,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6129,25 +6129,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -6948,9 +6955,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -7175,9 +7182,11 @@ dependencies = [
  "sqlx",
  "starknet",
  "starknet-crypto",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
+ "toml",
  "tower 0.4.13",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ mockall = "0.13.1"
 # Cryptography
 sha3 = "0.10.8"
 futures-util = "0.3.31"
+toml = "0.8.23"
 
 [package.metadata.sqlx]
 offline = true
@@ -71,3 +72,5 @@ offline = true
 pretty_assertions = "1.4.0"
 tokio-test = "0.4"
 mockito = "0.31"
+tempfile = "3.20.0"
+toml = "0.8.23"

--- a/src/proof_client/mod.rs
+++ b/src/proof_client/mod.rs
@@ -1,1 +1,2 @@
 pub mod input_generator;
+pub mod proof_generator;

--- a/src/proof_client/proof_generator.rs
+++ b/src/proof_client/proof_generator.rs
@@ -1,0 +1,50 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn run_scarb_build(project_path: &str) -> Result<PathBuf, String> {
+    let target_dir = Path::new(project_path);
+
+    if !target_dir.exists() {
+        return Err(format!("No Scarb project in this directory: {}", project_path));
+    }
+
+    println!("Building Scarb project at {:?}", target_dir);
+
+    let status = Command::new("scarb")
+        .arg("build")
+        .current_dir(&target_dir)
+        .status();
+
+    match status {
+        Ok(status) if status.success() => {
+            // we need to check the .toml file of the project
+            // so we can get the package name and compute its file/out folder
+            let scarb_toml_path = target_dir.join("Scarb.toml");
+            let toml_str = fs::read_to_string(&scarb_toml_path)
+                .map_err(|e| format!("Failed to read Scarb.toml: {}", e))?;
+            let parsed: toml::Value = toml_str
+                .parse()
+                .map_err(|e| format!("Failed to parse Scarb.toml: {}", e))?;
+
+            let package_name = parsed
+                .get("package")
+                .and_then(|pkg| pkg.get("name"))
+                .and_then(|name| name.as_str())
+                .ok_or("Could not find package.name in Scarb.toml")?;
+
+            let output_file = target_dir
+                .join("target/dev")
+                .join(format!("{}.sierra.json", package_name));
+
+            if output_file.exists() {
+                println!("Output file found: {:?}", output_file);
+                Ok(output_file)
+            } else {
+                Err(format!("❌ Output file not found: {:?}", output_file))
+            }
+        }
+        Ok(status) => Err(format!("❌ Build failed. Exit code: {:?}", status.code())),
+        Err(err) => Err(format!("❌ Failed to execute Scarb: {}", err)),
+    }
+}

--- a/tests/scarb_build.rs
+++ b/tests/scarb_build.rs
@@ -1,0 +1,60 @@
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+    use zeroxbridge_sequencer::proof_client::proof_generator::run_scarb_build;
+
+    #[test]
+    fn test_run_scarb_build_pass() {
+        let tmp_dir = tempdir().expect("Failed to create temporary directory");
+        let project_path = tmp_dir
+            .path()
+            .to_str()
+            .expect("Failed to convert path to string");
+
+        // we'll create a temp directory that'll eventually be deleted when this test
+        // goes out of scope so git won't track it.
+        let _ = fs::create_dir_all(Path::new(project_path).join("src"));
+        fs::write(
+            Path::new(project_path).join("Scarb.toml"),
+            r#"
+[package]
+name = "test_project"
+version = "0.1.0"
+
+[dependencies]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            Path::new(project_path).join("src/lib.cairo"),
+            r#"
+fn main() {
+  println!("Hello people of Cairo!!")
+}
+"#,
+        )
+        .unwrap();
+
+        let result = run_scarb_build(project_path);
+        assert!(
+            result.is_ok(),
+            "Scarb build should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_run_scarb_build_fail() {
+        let result = run_scarb_build("non_existent_path");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_lowercase()
+                .contains("no scarb project"),
+            "Expected missing project error"
+        );
+    }
+}


### PR DESCRIPTION
although the issue description said to work in the src/proof_generator dir. i couldn't locate such, so i added a file in the proof_client folder.

to test this, you can run cargo test --test scarb_build.

the test basically creates a temporary project that is dropped once the function is not in scope any more.

closes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new function to build Scarb projects and retrieve the output file path, with detailed error handling for missing files or build failures.
  * Exposed a new module for proof generation functionality.

* **Tests**
  * Introduced unit tests to verify successful and failed Scarb project builds, ensuring robust error handling for missing or invalid projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->