### PR TITLE
feat: switch L1 listener to single DepositEvent

### DIFF
--- a/migrations/20250724182944_unique_commitment_hash.sql
+++ b/migrations/20250724182944_unique_commitment_hash.sql
@@ -1,0 +1,2 @@
+-- Make commitment_hash unique in deposits table
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deposits_commitment_hash ON deposits (commitment_hash);

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -85,6 +85,30 @@ pub async fn insert_deposit(
     Ok(row_id)
 }
 
+pub async fn upsert_deposit(
+    conn:&PgPool,
+    stark_pub_key: &str,
+    amount: i64,
+    commitment_hash: &str,
+    status: &str
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO deposits (stark_pub_key, amount, commitment_hash, status)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (commitment_hash) DO UPDATE
+        SET status = EXCLUDED.status,
+        updated_at = NOW()
+        "#,
+        stark_pub_key,
+        amount,
+        commitment_hash,
+        status,
+    ).execute(conn).await?;
+
+    Ok(())
+}
+
 // new function
 pub async fn insert_deposit_hash_event(
     conn: &PgPool,


### PR DESCRIPTION
i also ensure that the commitment_hash is unique by indexing it in the deposits table (i included the required migration) so now, no two deposits can have the commitment hash.

this also introduces a retry/backoff mechanism in the fetch_events_logs_at_address function. for now, the max retries is 5. we can update this, if we need to increase though.

@JoE11-y, please lemme know what you think.

closes #85